### PR TITLE
Capture 'error' in ffmpeg stderr

### DIFF
--- a/src/cogs/music/music.py
+++ b/src/cogs/music/music.py
@@ -5,7 +5,7 @@ from discord.ext import commands
 from discord import app_commands
 from queue import Queue
 from cogs.music.song import Song
-from utils import discord_message, suggestor
+from utils import discord_message, suggestor, capture_ffmpeg
 from utils.config import ytdl, ffmpeg_options
 import traceback
 
@@ -209,9 +209,11 @@ class Music(commands.Cog):
         return {**songs, **prep_entry['latest_info']}
 
     def __prep_entry(self, entry: dict) -> dict:
+        capture_ffmpeg.capture(entry['url'])
+
         song = Song(entry['title'],
                     entry['webpage_url'],
-                    discord.FFmpegPCMAudio(entry['url'], stderr=open('error.log', 'a'), **ffmpeg_options))
+                    discord.FFmpegPCMAudio(entry['url'], **ffmpeg_options))
 
         suggest = suggestor.get_suggestions(entry['title'].split(' '), entry['tags'])
         return {

--- a/src/utils/capture_ffmpeg.py
+++ b/src/utils/capture_ffmpeg.py
@@ -1,0 +1,9 @@
+import subprocess
+
+def capture(entry_url):
+   cmd = ['ffmpeg', '-i', entry_url]
+   process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+   stdout, stderr = process.communicate()
+   error_lines = (line for line in stderr.decode().split('\n') if 'error' in line.lower())
+   for line in error_lines:
+      print(line)


### PR DESCRIPTION
Temp file approach doesn't seem nicer: without time.sleep(1), the stderr result is empty buffer. In contrast, this approach seems to monitor the entire process.