### PR TITLE
Allow error'd extractions from ytdl to pass through private videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode
+.vscode

--- a/src/cogs/music/music.py
+++ b/src/cogs/music/music.py
@@ -199,8 +199,9 @@ class Music(commands.Cog):
         songs_to_enqueue = []
         if 'entries' in data:
             for entry in data['entries']:
-                prep_entry = self.__prep_entry(entry)
-                songs_to_enqueue.append(prep_entry['song'])
+                if entry is not None:
+                    prep_entry = self.__prep_entry(entry)
+                    songs_to_enqueue.append(prep_entry['song'])
         else:
             prep_entry = self.__prep_entry(data)
             songs_to_enqueue.append(prep_entry['song'])

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -6,7 +6,7 @@ ytdl_format_options = {
     'restrictfilenames': True,
     'noplaylist': True,
     'nocheckcertificate': True,
-    'ignoreerrors': False,
+    'ignoreerrors': True,
     'logtostderr': False,
     'quiet': True,
     'no_warnings': True,


### PR DESCRIPTION
Playlists can have videos with different issues:
ERROR: [youtube] _KxlMjfY6Dg: Private video. Sign in if you've been granted access to this video 
ERROR: [youtube] JFHanoST-vI: Video unavailable. This video is no longer available because the YouTube account associated with this video has been terminated. 
ERROR: [youtube] obvizJRnezA: Video unavailable. This video is no longer available due to a copyright claim by Tadeusz Woźniak 

So just passing through them